### PR TITLE
Add RfQ Process page to Projects chapter

### DIFF
--- a/content/modules/compendium/pages/Projects/03_project_phases.adoc
+++ b/content/modules/compendium/pages/Projects/03_project_phases.adoc
@@ -76,7 +76,7 @@ See xref:../tools.adoc#infrastructure-pipelines[Infrastructure & Pipelines for P
 
 In particular, the Project Lead who is the main responsible for the project is elected.
 Depending on the size of the project, other xref:compendium:Projects/01_project_terms.adoc[roles] such as subgroup leads are also elected. 
-One or more service providers may be contracted to provide additional support.
+One or more service providers may be contracted to provide additional support via the xref:compendium:Projects/04_rfq_process.adoc[RfQ Process].
 
 This is followed by one or more development intervals, specifying, writing, and reviewing content internally until the document or documents are ready for the **Review Phase**.
 

--- a/content/modules/compendium/pages/Projects/04_rfq_process.adoc
+++ b/content/modules/compendium/pages/Projects/04_rfq_process.adoc
@@ -14,18 +14,18 @@ This page describes how the RfQ is prepared, published, evaluated, and awarded.
 == Process steps
 
 . The TM and project group write the RfQ document.
-. The TM and project group create the evaluation matrix.
+. The TM and project group create the evaluation matrix using the provided https://asamev.sharepoint.com/:x:/g/IQDm4IMHD50cTqxl60n5CGyoAaKhOm3qgZPMuUxlV948ers?e=AdYsTF[template].
 . The RfQ is published on the website, via the project-group email distribution list, and via the newsletter. (Responsible: ASAM Office)
 . Quotations are sent to the central offers inbox (offers@asam.net).
 . For each incoming offer:
 .. A receipt confirmation is sent to the submitter within 2 working days. (Responsible: ASAM Office)
-.. A preliminary check is done (e.g. validity of the offer). (Responsible: ASAM Office)
+.. A preliminary check is done (e.g., validity of the offer). (Responsible: ASAM Office)
 .. The offer is forwarded to TM/STC. (Responsible: ASAM Office)
-.. A formal check is done (e.g. all parts offered, terms and conditions, transfer of ownership of work results). (Responsible: TM/STC)
+.. A formal check is done (e.g., all parts offered, terms and conditions, transfer of ownership of work results). (Responsible: TM/STC)
 .. The offer is anonymized if required. (Responsible: TM/STC, assisted by the ASAM Office)
 .. The commercial and technical parts are separated. (Responsible: TM/STC, assisted by the ASAM Office)
 .. The evaluation matrix is prepared. (Responsible: TM/STC)
 . The project group performs the evaluation.
-. Results are presented in the TSC and a service provider is selected.
-. The contract with the winner is signed within 2 working days after the TSC decision. (Responsible: TM/STC/CEO)
+. Results are presented in the TSC, and a service provider is selected.
+. The contract with the winner is initiated within 2 working days after the TSC decision. (Responsible: TM/STC/CEO)
 . The remaining bidders are informed within 2 working days after contract confirmation. (Responsible: ASAM Office)

--- a/content/modules/compendium/pages/Projects/04_rfq_process.adoc
+++ b/content/modules/compendium/pages/Projects/04_rfq_process.adoc
@@ -1,0 +1,31 @@
+= RfQ Process
+:description: Describes the ASAM Request for Quotation (RfQ) and service-provider selection process.
+:keywords: rfq, quotation, service provider, project
+
+include::partial$_attributes.adoc[]
+
+
+== Introduction
+
+When a project requires external support, ASAM contracts a xref:compendium:Projects/01_project_terms.adoc#service-provider[Service Provider] through a public Request for Quotation (RfQ) process.
+This page describes how the RfQ is prepared, published, evaluated, and awarded.
+
+
+== Process steps
+
+. The TM and project group write the RfQ document.
+. The TM and project group create the evaluation matrix.
+. The RfQ is published on the website, via the project-group email distribution list, and via the newsletter. (Responsible: ASAM Office)
+. Quotations are sent to the central offers inbox (offers@asam.net).
+. For each incoming offer:
+.. A receipt confirmation is sent to the submitter within 2 working days. (Responsible: ASAM Office)
+.. A preliminary check is done (e.g. validity of the offer). (Responsible: ASAM Office)
+.. The offer is forwarded to TM/STC. (Responsible: ASAM Office)
+.. A formal check is done (e.g. all parts offered, terms and conditions, transfer of ownership of work results). (Responsible: TM/STC)
+.. The offer is anonymized if required. (Responsible: TM/STC, assisted by the ASAM Office)
+.. The commercial and technical parts are separated. (Responsible: TM/STC, assisted by the ASAM Office)
+.. The evaluation matrix is prepared. (Responsible: TM/STC)
+. The project group performs the evaluation.
+. Results are presented in the TSC and a service provider is selected.
+. The contract with the winner is signed within 2 working days after the TSC decision. (Responsible: TM/STC/CEO)
+. The remaining bidders are informed within 2 working days after contract confirmation. (Responsible: ASAM Office)


### PR DESCRIPTION
Documents the ASAM Request for Quotation and service-provider selection process (RfQ writing, publication, offer handling, evaluation, TSC selection, and contracting) as a new page in the Projects chapter, and cross-references it from the Development phase where service providers are mentioned.