### PR TITLE
Add Proposal Writing step and Project Initiator role

### DIFF
--- a/content/modules/compendium/pages/Projects/01_project_terms.adoc
+++ b/content/modules/compendium/pages/Projects/01_project_terms.adoc
@@ -38,6 +38,9 @@ Average commitment entails 1-2 hour meetings every 2 weeks during active develop
 
 == Project roles
 
+[[project-initiator]]
+Project Initiator:: The __Project Participant__ who authors and submits the project proposal during the Proposal Phase. The __Project Initiator__ prepares the project plan, estimates the required work efforts and an optional budget, and secures the minimum of three participating companies, which may include their own organization, that commit work resources to the project. The ASAM Office supports the __Project Initiator__ throughout the xref:compendium:Projects/03_project_phases.adoc#_proposal_writing[proposal writing] step.
+
 [[asam_or]]
 Office Responsible (OR):: The ASAM contact for a project. An __Office Responsible (OR)__ is an *ASAM employee* focussed on *coordinating project processes* and the *background work* behind a project.
 OR is responsible for informing their projects of the latest decisions and updates by the working day following the __Technical Steering Committee (TSC)__ meeting.

--- a/content/modules/compendium/pages/Projects/03_project_phases.adoc
+++ b/content/modules/compendium/pages/Projects/03_project_phases.adoc
@@ -76,7 +76,7 @@ See xref:../tools.adoc#infrastructure-pipelines[Infrastructure & Pipelines for P
 
 In particular, the Project Lead who is the main responsible for the project is elected.
 Depending on the size of the project, other xref:compendium:Projects/01_project_terms.adoc[roles] such as subgroup leads are also elected. 
-One or more service providers may be contracted to provide additional support.
+One or more service providers may be contracted to provide additional support via the xref:compendium:Projects/04_rfq_process.adoc[RfQ Process].
 
 This is followed by one or more development intervals, specifying, writing, and reviewing content internally until the document or documents are ready for the **Review Phase**.
 

--- a/content/modules/compendium/pages/Projects/03_project_phases.adoc
+++ b/content/modules/compendium/pages/Projects/03_project_phases.adoc
@@ -10,7 +10,7 @@ include::partial$_attributes.adoc[]
 == Introduction
 
 Besides xref:compendium:Projects/02_project_types.adoc[different types of projects], there are four main project phases that ASAM defines.
-Not all projects must necessarily pass through all these phases.
+Not all projects shall necessarily pass through all these phases.
 See the phase descriptions below for more details.
 
 image::compendium:Projects/project_lifecycle.drawio.svg[alt=The ASAM Project Phases, title=The ASAM project phases]
@@ -52,7 +52,7 @@ They take into account the input from the preceding proposal workshop, if one wa
 They define which content shall be included in the standard.
 They create a project plan and estimate the required work efforts and an optional budget.
 
-The Project Initiator must secure a minimum of three companies, which may include their own organization, that commit work resources to the project.
+The Project Initiator shall secure a minimum of three companies, which may include their own organization, that commit work resources to the project.
 
 The ASAM Office supports the proposal author throughout this step.
 

--- a/content/modules/compendium/pages/Projects/03_project_phases.adoc
+++ b/content/modules/compendium/pages/Projects/03_project_phases.adoc
@@ -45,6 +45,17 @@ Should a project be approved, it proceeds on to the **Development phase**.
 
 NOTE: Download the project proposal templates https://asamev.sharepoint.com/:f:/g/EpWO8zVcXvBCu-EG7Xr7H4IBAZpaZTSdqLNhH2A9B2GRiA?e=L6GPnf[here].
 
+=== Proposal writing
+
+The xref:compendium:Projects/01_project_terms.adoc#project-initiator[Project Initiator] prepares the project proposal.
+They take into account the input from the preceding proposal workshop, if one was held.
+They define which content shall be included in the standard.
+They create a project plan and estimate the required work efforts and an optional budget.
+
+The Project Initiator must secure a minimum of three companies, which may include their own organization, that commit work resources to the project.
+
+The ASAM Office supports the proposal author throughout this step.
+
 
 // Additional information:: xref:compendium:proposal_phase.adoc[]
 == Development phase

--- a/content/modules/compendium/pages/Projects/04_rfq_process.adoc
+++ b/content/modules/compendium/pages/Projects/04_rfq_process.adoc
@@ -1,0 +1,31 @@
+= RfQ Process
+:description: Describes the ASAM Request for Quotation (RfQ) and service-provider selection process.
+:keywords: rfq, quotation, service provider, project
+
+include::partial$_attributes.adoc[]
+
+
+== Introduction
+
+When a project requires external support, ASAM contracts a xref:compendium:Projects/01_project_terms.adoc#service-provider[Service Provider] through a public Request for Quotation (RfQ) process.
+This page describes how the RfQ is prepared, published, evaluated, and awarded.
+
+
+== Process steps
+
+. The TM and project group write the RfQ document.
+. The TM and project group create the evaluation matrix.
+. The RfQ is published on the website, via the project-group email distribution list, and via the newsletter. (Responsible: ASAM Office)
+. Quotations are sent to the central offers inbox (offers@asam.net).
+. For each incoming offer:
+.. A receipt confirmation is sent to the submitter within 2 working days. (Responsible: ASAM Office)
+.. A preliminary check is done (e.g. validity of the offer). (Responsible: ASAM Office)
+.. The offer is forwarded to TM/STC. (Responsible: ASAM Office)
+.. A formal check is done (e.g. all parts offered, terms and conditions, transfer of ownership of work results). (Responsible: TM/STC)
+.. The offer is anonymized if required. (Responsible: TM/STC, assisted by the ASAM Office)
+.. The commercial and technical parts are separated. (Responsible: TM/STC, assisted by the ASAM Office)
+.. The evaluation matrix is prepared. (Responsible: TM/STC)
+. The project group performs the evaluation.
+. Results are presented in the TSC and a service provider is selected.
+. The contract with the winner is signed within 2 working days after the TSC decision. (Responsible: TM/STC/CEO)
+. The remaining bidders are informed within 2 working days after contract confirmation. (Responsible: ASAM Office)


### PR DESCRIPTION
## What
Adds the "Proposal Writing" process step under the Proposal Phase and a new "Project Initiator" role to the Project Guide, aligning it with the ASAM Development Process (Proposal Phase) content from the ASAM web.

## Changes
- **03_project_phases.adoc** — new `=== Proposal writing` subsection under the Proposal phase: proposal author prepares the proposal, considers proposal-workshop input, defines standard content, creates a project plan with effort/optional budget estimates, secures a minimum of three committing companies, with ASAM Office support.
- **01_project_terms.adoc** — new `Project Initiator` role in the Project roles list, matching the existing role formatting and anchors.

Roles only; gender-neutral; no invented steps, numbers, or policy.