### PR TITLE
Add Member onboarding page to Projects chapter

### DIFF
--- a/content/modules/compendium/pages/Projects/03_project_phases.adoc
+++ b/content/modules/compendium/pages/Projects/03_project_phases.adoc
@@ -75,8 +75,11 @@ NOTE: Before holding the kickoff workshop, make sure the project infrastructure 
 See xref:../tools.adoc#infrastructure-pipelines[Infrastructure & Pipelines for Projects] for details on required steps.
 
 In particular, the Project Lead who is the main responsible for the project is elected.
-Depending on the size of the project, other xref:compendium:Projects/01_project_terms.adoc[roles] such as subgroup leads are also elected. 
+Depending on the size of the project, other xref:compendium:Projects/01_project_terms.adoc[roles] such as subgroup leads are also elected.
 One or more service providers may be contracted to provide additional support.
+
+As new members join the project group, they are onboarded and provided with their access credentials.
+See xref:compendium:Projects/05_member_onboarding.adoc[Member onboarding] for the onboarding steps and the confirmation that ensures every new member receives their credentials.
 
 This is followed by one or more development intervals, specifying, writing, and reviewing content internally until the document or documents are ready for the **Review Phase**.
 

--- a/content/modules/compendium/pages/Projects/05_member_onboarding.adoc
+++ b/content/modules/compendium/pages/Projects/05_member_onboarding.adoc
@@ -1,0 +1,20 @@
+= Member onboarding
+:description: Describes how new project members are onboarded and receive their access credentials.
+:keywords: onboarding, member, credentials, distribution list, project
+
+include::partial$_attributes.adoc[]
+
+
+== Introduction
+
+When a new xref:compendium:Projects/01_project_terms.adoc#project-member[project member] joins a project group, ASAM onboards them and provides their access credentials.
+This page describes the onboarding process and the confirmation step that ensures every new member reliably receives their onboarding email and credentials.
+
+
+== Process steps
+
+. The new project-group member is added to the relevant distribution lists. (Responsible: ASAM Office)
+. An invitation email, including the member's access credentials, is sent to the new member when they are added to the distribution lists.
+. In parallel, a separate email *without credentials* is sent to the xref:compendium:Projects/01_project_terms.adoc#asam_or[Office Responsible (OR)] to notify them of the new member.
+. The new member clicks the confirmation link in the invitation email to confirm they have received the email.
+. If the member has not confirmed within five working days, the OR follows up directly with that member. (Supported by the ASAM Office)


### PR DESCRIPTION
Document the process for onboarding new project members at the start of the Development phase: addition to distribution lists, the invitation email with access credentials, the parallel notification to the Office Responsible, the confirmation link, and OR follow-up after five working days. Cross-reference the new page from the Development phase.